### PR TITLE
added safe filter to render_content

### DIFF
--- a/aiohttp_debugtoolbar/templates/exception.jinja2
+++ b/aiohttp_debugtoolbar/templates/exception.jinja2
@@ -30,7 +30,7 @@
       <pre class= "errormsg">{{ exception }}</pre>
     </div>
     <h2 class="traceback">Traceback <small>(most recent call last)</small></h2>
-    {{ summary }}
+    {{ summary|safe }}
     <div class="plain">
       <p>
         <input type="hidden" name="language" value="pytb">

--- a/aiohttp_debugtoolbar/templates/exception_summary.jinja2
+++ b/aiohttp_debugtoolbar/templates/exception_summary.jinja2
@@ -1,5 +1,5 @@
 <div class="{{ classes }}">
   {{ title }}
-  <ul>{{ frames }}</ul>
-  {{ description }}
+  <ul>{{ frames|safe }}</ul>
+  {{ description|safe }}
 </div>

--- a/aiohttp_debugtoolbar/templates/global_tab.jinja2
+++ b/aiohttp_debugtoolbar/templates/global_tab.jinja2
@@ -46,7 +46,7 @@
         </div>
         <div class="pDebugPanelContent">
           <div class="scroll">
-        {{ panel.render_content(request) }}
+        {{ panel.render_content(request)|safe }}
           </div>
         </div>
       </div>

--- a/aiohttp_debugtoolbar/templates/history_tab.jinja2
+++ b/aiohttp_debugtoolbar/templates/history_tab.jinja2
@@ -50,7 +50,7 @@
             </div>
             <div class="pDebugPanelContent">
               <div class="scroll">
-                {{ panel.render_content(request) }}
+                {{ panel.render_content(request)|safe }}
               </div>
             </div>
           </div>


### PR DESCRIPTION
For the some reasons in my workspace tabs content (Performance, Traceback, etc.) and traceback were rendering html as plaint text, this little patch fix this issue.