### PR TITLE
Fix warning

### DIFF
--- a/aiohttp_debugtoolbar/tbtools/tbtools.py
+++ b/aiohttp_debugtoolbar/tbtools/tbtools.py
@@ -25,7 +25,7 @@ from ..utils import escape
 from ..utils import ROOT_ROUTE_NAME
 from ..utils import EXC_ROUTE_NAME
 _coding_re = re.compile(r'coding[:=]\s*([-\w.]+)')
-_line_re = re.compile(r'^(.*?)$(?m)')
+_line_re = re.compile(r'^(.*?)$', re.M)
 _funcdef_re = re.compile(r'^(\s*(?:async\s+?)?def\s)|'
                          r'(.*(?<!\w)lambda(:|\s))|^(\s*@)')
 UTF8_COOKIE = '\xef\xbb\xbf'


### PR DESCRIPTION
This fixes a warning on Python 3.8.

You can see the warning for example when running python with the `-We` option.